### PR TITLE
add healthcheck to s-mcn http lb

### DIFF
--- a/workflow-guides/smcn/mcn-distributed-apps-l3/terraform/workload/xc_loadbalancer.tf
+++ b/workflow-guides/smcn/mcn-distributed-apps-l3/terraform/workload/xc_loadbalancer.tf
@@ -4,6 +4,22 @@ resource "volterra_namespace" "this" {
   description = format("Namespace for %s", local.namespace)
 }
 
+resource "volterra_healthcheck" "aws-hc" {
+  name = format("%s-aws-hc", local.name)
+  namespace = local.namespace
+  description = format("Healthcheck for origin server %s", local.aws_origin_server)
+  http_health_check {
+    path = "/"
+    host_header = local.app_domain
+    expected_status_codes = "200-200"
+  }
+  unhealthy_threshold = 1
+  healthy_threshold = 3
+  interval = 10
+  timeout = 5
+  depends_on = [ volterra_namespace.this ]
+}
+
 resource "volterra_origin_pool" "aws-op" {
   name                   = format("%s-xcop-aws", local.name)
   namespace              = local.namespace
@@ -34,6 +50,10 @@ resource "volterra_origin_pool" "aws-op" {
             name = local.aws_site_name
           }
         }  
+      }
+      healthcheck {
+        name = volterra_healthcheck.aws-hc.name
+        namespace = local.namespace
       }
     }
   }

--- a/workflow-guides/smcn/mcn-distributed-apps-l3/terraform/workload/xc_loadbalancer.tf
+++ b/workflow-guides/smcn/mcn-distributed-apps-l3/terraform/workload/xc_loadbalancer.tf
@@ -11,7 +11,7 @@ resource "volterra_healthcheck" "aws-hc" {
   http_health_check {
     path = "/"
     host_header = local.app_domain
-    expected_status_codes = "200"
+    expected_status_codes = [ "200" ]
   }
   unhealthy_threshold = 1
   healthy_threshold = 3

--- a/workflow-guides/smcn/mcn-distributed-apps-l3/terraform/workload/xc_loadbalancer.tf
+++ b/workflow-guides/smcn/mcn-distributed-apps-l3/terraform/workload/xc_loadbalancer.tf
@@ -11,7 +11,7 @@ resource "volterra_healthcheck" "aws-hc" {
   http_health_check {
     path = "/"
     host_header = local.app_domain
-    expected_status_codes = "200-200"
+    expected_status_codes = "200"
   }
   unhealthy_threshold = 1
   healthy_threshold = 3

--- a/workflow-guides/smcn/mcn-distributed-apps-l3/terraform/workload/xc_loadbalancer.tf
+++ b/workflow-guides/smcn/mcn-distributed-apps-l3/terraform/workload/xc_loadbalancer.tf
@@ -51,10 +51,6 @@ resource "volterra_origin_pool" "aws-op" {
           }
         }  
       }
-      healthcheck {
-        name = volterra_healthcheck.aws-hc.name
-        namespace = local.namespace
-      }
     }
   }
   /* dynamic "origin_servers" {
@@ -65,6 +61,10 @@ resource "volterra_origin_pool" "aws-op" {
       } 
     }
   } */
+  healthcheck {
+        name = volterra_healthcheck.aws-hc.name
+        namespace = local.namespace
+  }
   no_tls = true
   port = local.aws_origin_port
   endpoint_selection     = "LOCAL_PREFERRED"


### PR DESCRIPTION
Add healthcheck and use app_domain Host header to reach the origin server in AWS. Needed in order to bring up the origin pool when frontend is NGINX