### PR TITLE
Add lifecycle block to enable update stopping on Compute Instance

### DIFF
--- a/f5/xc/securemesh2/gcp/main.tf
+++ b/f5/xc/securemesh2/gcp/main.tf
@@ -60,4 +60,17 @@ resource "google_compute_instance" "smv2_instance" {
       "https://www.googleapis.com/auth/servicecontrol"
     ])
   }
+  
+  lifecycle {
+    ignore_changes = [
+      machine_type,
+      min_cpu_platform,
+      service_account,
+      enable_display,
+      shielded_instance_config,
+      scheduling[0].node_affinities,
+      scheduling[0].max_run_duration,
+      network_interface,
+    ]
+  }
 }

--- a/f5/xc/securemesh2/gcp/main.tf
+++ b/f5/xc/securemesh2/gcp/main.tf
@@ -11,6 +11,7 @@ resource "google_compute_instance" "smv2_instance" {
   name = "${var.goog_cm_deployment_name}-${random_id.rand_id.hex}-${count.index + 1}"
   machine_type = var.machine_type
   zone = var.zones[count.index]
+  allow_stopping_for_update = true
 
   tags = var.network_tags
 


### PR DESCRIPTION
This pull request introduces improvements to the `google_compute_instance` resource configuration in the `f5/xc/securemesh2/gcp/main.tf` file. The main changes enhance instance update flexibility and stability by allowing certain updates without resource recreation and by instructing Terraform to ignore changes to specific fields.

**Instance update and lifecycle management improvements:**

* Set `allow_stopping_for_update = true` to enable instances to be stopped and updated in place, reducing downtime during updates.
* Added a `lifecycle` block with `ignore_changes` for several fields (e.g., `machine_type`, `service_account`, `network_interface`) to prevent unnecessary resource recreation when these fields change, making deployments more resilient to configuration drift.