### PR TITLE
Add output for private IP addresses of SLI network interface in GCP

### DIFF
--- a/f5/xc/securemesh2/gcp/outputs.tf
+++ b/f5/xc/securemesh2/gcp/outputs.tf
@@ -9,3 +9,10 @@ output "instances_ephemeral_ips" {
     for instance in google_compute_instance.smv2_instance : instance.network_interface[0].access_config[0].nat_ip
   ]
 }
+
+output "sli_private_ips" {
+  description = "Private (internal) IP addresses of the SLI network interface (nic1) for all instances."
+  value = [
+    for instance in google_compute_instance.smv2_instance : instance.network_interface[1].network_ip
+  ]
+}


### PR DESCRIPTION
This pull request adds a new output to the Terraform configuration to expose the private (internal) IP addresses of the SLI network interface for all instances. This makes it easier to reference these internal IPs in other modules or outputs.

**Infrastructure Outputs:**

* Added a new output `sli_private_ips` in `outputs.tf` to export the internal IP addresses from the second network interface (`nic1`) of all `smv2_instance` resources.